### PR TITLE
Update default Sentry environment and level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slf-sentry",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slf-sentry",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^7.12.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slf-sentry",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Surikat Log Facade, sentry driver",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/createSlfSentryDriver.ts
+++ b/src/createSlfSentryDriver.ts
@@ -3,7 +3,7 @@ import { Event } from 'slf';
 
 export interface CreateSlfSentryLoggerOptions {
   debug?: boolean;
-  level: string;
+  level?: string;
   environment?: string;
   levels?: Array<string>;
 }
@@ -12,9 +12,12 @@ let isInitialized = false;
 
 export default function createSlfSentryDriver(
   sentryUrl: string,
-  { debug, environment = 'dev', level, levels = ['error'] }: CreateSlfSentryLoggerOptions = {
-    level: 'error'
-  }
+  {
+    debug,
+    environment = process.env.SENTRY_ENV ?? 'dev',
+    level = 'error',
+    levels = ['error']
+  }: CreateSlfSentryLoggerOptions = {}
 ) {
   const levelIndex = levels.indexOf(level);
 


### PR DESCRIPTION
Use `SENTRY_ENV` for `environment` if specified, fallback to `dev`.

Default `level` to `error`.