### PR TITLE
feature: disable integrations options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slf-sentry",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slf-sentry",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^7.12.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slf-sentry",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Surikat Log Facade, sentry driver",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
We currently can't disable any integrations. Incase we want our custom way of handling these errors that sentry node handles.