### PR TITLE
Add support for Sentry release name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slf-sentry",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slf-sentry",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^7.12.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slf-sentry",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Surikat Log Facade, sentry driver",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/createSlfSentryDriver.ts
+++ b/src/createSlfSentryDriver.ts
@@ -6,18 +6,14 @@ export interface CreateSlfSentryLoggerOptions {
   level?: string;
   environment?: string;
   levels?: Array<string>;
+  release?: string;
 }
 
 let isInitialized = false;
 
 export default function createSlfSentryDriver(
   sentryUrl: string,
-  {
-    debug,
-    environment = process.env.SENTRY_ENV ?? 'dev',
-    level = 'error',
-    levels = ['error']
-  }: CreateSlfSentryLoggerOptions = {}
+  { debug, environment = process.env.SENTRY_ENV ?? 'dev', level = 'error', levels = ['error'], release }: CreateSlfSentryLoggerOptions = {}
 ) {
   const levelIndex = levels.indexOf(level);
 
@@ -27,7 +23,8 @@ export default function createSlfSentryDriver(
         dsn: sentryUrl,
         tracesSampleRate: 1.0,
         debug: debug ?? ['fat', 'dev'].includes(environment.toLowerCase()),
-        environment
+        environment,
+        release
       });
       isInitialized = true;
     } catch (err) {


### PR DESCRIPTION
If provided when the Sentry SLF driver is created, pass through to the Sentry init function.